### PR TITLE
Fix TileSetWatcher resource leaks on deletion

### DIFF
--- a/addons/TileMapDual/tile_map_dual.gd
+++ b/addons/TileMapDual/tile_map_dual.gd
@@ -57,6 +57,12 @@ func _ready() -> void:
 	_changed()
 
 
+func _notification(what: int) -> void:
+	# Leaving the tree can be temporary, so release watcher state only on deletion.
+	if what == NOTIFICATION_PREDELETE and _tileset_watcher != null:
+		_tileset_watcher.check_tile_set(null)
+
+
 func _process(delta: float) -> void: # Only used inside the editor
 	if refresh_time < 0.0:
 		return


### PR DESCRIPTION
Fixes #75.

## What changed
- Release the `TileSetWatcher` graph from `NOTIFICATION_PREDELETE` by calling the existing `check_tile_set(null)` cleanup path.
- Keep watcher state intact when a `TileMapDual` only leaves and later re-enters the scene tree.

## Why `NOTIFICATION_PREDELETE`
`_exit_tree()` also runs for temporary removal and reparenting, while `_ready()` does not automatically run again on re-entry. Cleaning up only immediately before deletion avoids leaving a re-added node with stale watcher/display state.

## Verification
- Before the fix, a downstream Godot 4.6.2 headless subprocess reproduced 20 leaked DummyTexture RIDs, leaked ObjectDB instances, and 23 resources still in use.
- After the fix, the same subprocess exits cleanly with no RID, ObjectDB, or Resource leak reports.
- This repository's `Hexagonal.tscn` and `MultipleAtlases.tscn` examples both run and exit cleanly with Godot 4.6.2 headless.

The production change is limited to six added lines in `tile_map_dual.gd`.